### PR TITLE
Add badge image for crate version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 pineapplepizza-rust-reference &emsp; [![Latest Version]][crates.io]
 =============================
 
+[Latest Version]: https://img.shields.io/crates/v/pineapplepizza.svg
 [crates.io]: https://crates.io/crates/pineapplepizza
 
 The reference parser for [pineapplepizza](https://github.com/flaviusb/pineapplepizza).


### PR DESCRIPTION
Use [shields.io](https://shields.io) to generate a [crates.io](https://crates.io) badge image for the Readme.